### PR TITLE
Always compare case sensitive ignoring user's ignorecase setting

### DIFF
--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -550,7 +550,7 @@ function renamer#PerformRename() "{{{1
   let uniqueIntermediateNames = []
   let i = 0
   while i < numOriginalFiles
-    if b:renamerOriginalPathfileList[i] != modifiedFileList[i]
+    if b:renamerOriginalPathfileList[i] !=# modifiedFileList[i]
       if filewritable(b:renamerOriginalPathfileList[i])
         " let newName = substitute(modifiedFileList[i], escape(b:renamerDirectory.'/','/\'),'','')
         let newName = substitute(modifiedFileList[i], b:renamerDirectoryEscaped,'','')


### PR DESCRIPTION
User settings should not affect the general behaviour of this plugin. I suggest changing this to always compare case sensitive.
