### PR TITLE
Ingo merge ingokarkat fork

### DIFF
--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -258,7 +258,7 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
         let fileEntryNumber += 1
       endif
     endif
-    let b:renamerMaxWidth = max([b:renamerMaxWidth, len(text)])
+    let b:renamerMaxWidth = max([b:renamerMaxWidth, (exists('*strdisplaywidth') ? strdisplaywidth(text) : len(text))])
     let i += 1
   endwhile
 

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -493,7 +493,7 @@ function renamer#PerformRename() "{{{1
   endfor
 
   if invalidFileCount
-    echoe invalidFileCount." name(s) had errors. Resolve and retry..."
+    call s:EchoErr(invalidFileCount." name(s) had errors. Resolve and retry...")
     return
   endif
 
@@ -501,7 +501,7 @@ function renamer#PerformRename() "{{{1
   let numModifiedFiles = len(modifiedFileList)
 
   if numModifiedFiles != numOriginalFiles
-    echoe 'Dir contains '.numOriginalFiles.' writeable files, but there are '.numModifiedFiles.' listed in buffer.  These numbers should be equal'
+    call s:EchoErr('Dir contains '.numOriginalFiles.' writeable files, but there are '.numModifiedFiles.' listed in buffer.  These numbers should be equal')
     return
   endif
 
@@ -537,7 +537,7 @@ function renamer#PerformRename() "{{{1
     for f in duplicatesFound
       echom f
     endfor
-    echoe "Fix the duplicates and try again"
+    call s:EchoErr("Fix the duplicates and try again")
     return
   endif
 
@@ -555,7 +555,7 @@ function renamer#PerformRename() "{{{1
           call mkdir(newDir, 'p')
         endif
         if !isdirectory(newDir)
-          echoe "Attempting to rename '".b:renamerOriginalPathfileList[i]."' to '".newName."' but directory ".newDir." couldn't be created!"
+          call s:EchoErr("Attempting to rename '".b:renamerOriginalPathfileList[i]."' to '".newName."' but directory ".newDir." couldn't be created!")
           " Continue anyway with the other files since we've already started renaming
         else
           " To allow moving files to other directories, slashes must be "escaped" in a special way
@@ -563,7 +563,7 @@ function renamer#PerformRename() "{{{1
           let newName = substitute(newName, '\\', '_BACKSLASH_', 'g')
           let uniqueIntermediateName = b:renamerDirectory.'/'.i.'_GOING_TO_'.newName
           if rename(b:renamerOriginalPathfileList[i], uniqueIntermediateName) != 0
-            echoe "Unable to rename '".b:renamerOriginalPathfileList[i]."' to '".uniqueIntermediateName."'"
+            call s:EchoErr("Unable to rename '".b:renamerOriginalPathfileList[i]."' to '".uniqueIntermediateName."'")
             " Continue anyway with the other files since we've already started renaming
           else
             let uniqueIntermediateNames += [ uniqueIntermediateName ]
@@ -582,11 +582,11 @@ function renamer#PerformRename() "{{{1
     let newName = substitute(newName, '_FORWSLASH_', '/', 'g')
     let newName = substitute(newName, '_BACKSLASH_', '\', 'g')
     if filereadable(newName)
-      echoe "A file called '".newName."' already exists - cancelling rename!"
+      call s:EchoErr("A file called '".newName."' already exists - cancelling rename!")
       " Continue anyway with the other files since we've already started renaming
     else
       if rename(intermediateName, newName) != 0
-        echoe "Unable to rename '".intermediateName."' to '".newName."'"
+        call s:EchoErr("Unable to rename '".intermediateName."' to '".newName."'")
         " Continue anyway with the other files since we've already started renaming
       endif
     endif
@@ -676,7 +676,7 @@ function renamer#DeleteEntry() "{{{1
       let i += 1
     endwhile
     if listIndex == -1
-      echoe "Renamer: DeleteEntry couldn't find entry '".entry."'"
+      call s:EchoErr("Renamer: DeleteEntry couldn't find entry '".entry."'")
       return
     endif
   endif
@@ -705,7 +705,7 @@ function renamer#DeleteEntry() "{{{1
         let errcode = delete(entryPath)
         if errcode != 0
           " Failed - error message
-          echoe "Unable to delete directory '".entryPath."' - this script is limited to only delete empty directories"
+          call s:EchoErr("Unable to delete directory '".entryPath."' - this script is limited to only delete empty directories")
           return
         endif
       endif
@@ -714,7 +714,7 @@ function renamer#DeleteEntry() "{{{1
       let errcode = delete(entryPath)
       if errcode != 0
         " Failed - error message
-        echoe "Unable to delete file '".entryPath."'"
+        call s:EchoErr("Unable to delete file '".entryPath."'")
         return
       endif
     endif
@@ -756,6 +756,13 @@ function renamer#Refresh() "{{{1
 endfunction
 
 " Support functions        {{{1
+
+function s:EchoErr( msg ) "{{{2
+  let v:errmsg = a:msg
+  echohl ErrorMsg
+  echomsg v:errmsg
+  echohl None
+endfunction
 
 function renamer#Path(p)       "{{{2
   " Make sure a path has proper form

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -394,6 +394,11 @@ function renamer#CreateOriginalFileWindow(needNewWindow, maxWidth, entryDisplayT
     " Create a new window to the left
     lefta vnew
     setlocal modifiable
+    setlocal nonumber
+    if exists('+relativenumber')
+      setlocal norelativenumber
+    endif
+    setlocal foldcolumn=0
 
     " Set the header text
     let headerText = [ s:hashes.'ORIGINAL' ,

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -660,7 +660,7 @@ function renamer#ChangeDirectory() "{{{1
   " We must also change the current directory, else it can happen
   " that we are trying to rename the directory we're currently in,
   " which is never going to work
-  exec 'cd "'.b:renamerDirectory . '"'
+  exec 'cd' fnameescape(b:renamerDirectory)
 
   " Now update the display for the new directory
   call renamer#Start(0,lineForNewBuffer,b:renamerDirectory)

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -12,7 +12,7 @@ let s:hashes = '### '
 let s:linksTo = 'LinksTo: '
 let s:linkPrefix = ' '.s:hashes.s:linksTo
 let s:header = [
-      \ "Renamer: change names then give command :Ren (:w or :wq if enabled)\n" ,
+      \ "Renamer: change names then give command :Ren" . (g:RenamerSupportColonWToRename ? " (or :w)" : '') . "\n" ,
       \ "ENTER=chdir, T=toggle original files, F5=refresh, Ctrl-Del=delete\n" ,
       \ ">=one more level, <=one less level\n" ,
       \ "Do not change the number of files listed (unless deleting)\n"

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -435,6 +435,13 @@ function renamer#CreateOriginalFileWindow(needNewWindow, maxWidth, entryDisplayT
   " Position the cursor on the same line as the main window
   call cursor(currentLine,1)
 
+  " Setup syntax
+  if has("syntax")
+    exec "syn match RenamerSecondaryInstructions '^\s*".s:hashes.".*'"
+    syn match RenamerOriginalDirectoryName       '^\s*[^#].*[/\\]$'
+    syn match RenamerOriginalFilename            '^\s*[^#].*[/\\]\@<!$'
+  endif
+
   " Set the width of the left hand window, as small as we can
   " 14 is the minimum reasonable, so set winwidth to that
   " to prevent vim enlarging it

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -84,13 +84,13 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
     if bufname('') != '' || &mod
       new
     else
-      normal! 1GVGd
+      %delete _
     endif
     let b:renamerSavedDirectoryLocations = {}
     let b:renamerPathDepth = g:RenamerInitialPathDepth
   else
     " b) deleting the existing window content if renamer is already running
-    normal! 1GVGd
+    %delete _
   endif
 
   if g:RenamerOriginalFileWindowEnabled
@@ -273,7 +273,7 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
     put =b:renamerEntryDisplayText
   endif
   " Remove a blank line created by 'put'
-  normal! ggdd
+  1delete _
 
   " Set the buffer type
   setlocal buftype=nofile
@@ -477,13 +477,8 @@ function renamer#PerformRename() "{{{1
   " Save the current line number, to return to it after renaming
   let savedLineNumber = line('.')
 
-  " Get the current lines, except the first
-  let saved_z = @z
-  normal! 1GVG"zy
-  let bufferText = @z
-  let @z = saved_z
-
-  let splitBufferText = split(bufferText, "\n")
+  " Get the current lines
+  let splitBufferText = getline(1, '$')
   let modifiedFileList = []
   let lineNo = 0
   let invalidFileCount = 0

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -331,21 +331,14 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
       let i += 1
     endwhile
 
-    " Link the highlights to user-setable colours
-    exec "highlight link RenamerPrimaryInstructions " . g:RenamerHighlightForPrimaryInstructions
-    exec "highlight link RenamerSecondaryInstructions " . g:RenamerHighlightForSecondaryInstructions
-    exec "highlight link RenamerLinkInfo " . g:RenamerHighlightForLinkInfo
-    exec "highlight link RenamerModifiedFilename " . g:RenamerHighlightForModifiedFilename
-    exec "highlight link RenamerOriginalFilename " . g:RenamerHighlightForOriginalFilename
-    exec "highlight link RenamerNonwriteableEntries " . g:RenamerHighlightForNonWriteableEntries
-    " Make directories a bold version of files if set to 'bold'
-    if g:RenamerHighlightForOriginalDirectoryName == 'bold'
-      let originalFilenameHighlightString = renamer#GetHighlightString(g:RenamerHighlightForOriginalFilename)
-      let originalDirectoryNameHighlightString = renamer#AddBoldToHighlightGroupDefinition(originalFilenameHighlightString)
-      exec "highlight RenamerOriginalDirectoryName " . originalDirectoryNameHighlightString
-    else
-      exec "highlight link RenamerOriginalDirectoryName " . g:RenamerHighlightForOriginalDirectoryName
-    endif
+    " Presets for the highlights
+    highlight def link RenamerPrimaryInstructions Title
+    highlight def link RenamerSecondaryInstructions Comment
+    highlight def link RenamerLinkInfo PreProc
+    highlight def link RenamerModifiedFilename Statement
+    highlight def link RenamerOriginalFilename Normal
+    highlight def link RenamerNonwriteableEntries NonText
+    highlight def link RenamerOriginalDirectoryName Directory
   endif
 
   " Define command to do the rename
@@ -802,52 +795,6 @@ function renamer#Path(p)       "{{{2
   let returnPath=substitute(returnPath, '//\+', '/', 'g')
   return returnPath
 endfunction
-
-function renamer#GetHighlightString(group) "{{{2
-  " Given a named highlight group, return the string representing the settings for it
-  if !hlexists(a:group)
-    echoe "Error in GetHighlightString: no highlight group exists called " . a:group
-    return ''
-  endif
-
-  let hlid = hlID(a:group)
-  let synid = synIDtrans(hlid)
-  let result = ''
-  for mode in ['term', 'cterm', 'gui']
-    for what in ['fg', 'bg']
-      let attr = synIDattr(synid, what, mode)
-      if attr != '' && attr != -1
-        let result .= ' ' . mode . what . '=' . attr
-      endif
-    endfor
-    for what in ['bold', 'italic', 'reverse', 'inverse', 'underline', 'undercurl']
-      let attr = synIDattr(synid, what, mode)
-      if attr == 1
-        " Don't bother supporting multiple options, like term=bold,underline
-        let result .= ' ' . mode . '=' . what
-      endif
-    endfor
-  endfor
-  return result
-endfunction
-
-function renamer#AddBoldToHighlightGroupDefinition(string) "{{{2
-  " Function to add the keyword "bold" where appropriate to a highlight definition string
-  let string = a:string
-  let string .= ' gui=bold'
-  if string =~ '\<term=' && string !~ '\<term=bold'
-    let string = substitute(string, '\<term=', 'term=bold,', '')
-  else
-    let string .= ' term=bold'
-  endif
-  if string =~ '\<cterm=' && string !~ '\<cterm=bold'
-    let string = substitute(string, '\<cterm=', 'cterm=bold,', '')
-  else
-    let string .= ' cterm=bold'
-  endif
-  return string
-endfunction
-
 
 function renamer#ValidatePathfile(dir, line, lineNo) "{{{2
   " Validate characters provided

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -392,7 +392,12 @@ function renamer#CreateOriginalFileWindow(needNewWindow, maxWidth, entryDisplayT
 
   if a:needNewWindow || g:RenamerOriginalFileWindowEnabled == 2
     " Create a new window to the left
-    lefta vnew
+    " 14 is the minimum reasonable, so set initial width to that
+    lefta 14vnew
+
+    " and prevent vim shrinking it
+    setlocal winwidth=14
+
     setlocal modifiable
     setlocal nonumber
     if exists('+relativenumber')
@@ -443,10 +448,7 @@ function renamer#CreateOriginalFileWindow(needNewWindow, maxWidth, entryDisplayT
   endif
 
   " Set the width of the left hand window, as small as we can
-  " 14 is the minimum reasonable, so set winwidth to that
-  " to prevent vim enlarging it
-  set winwidth=14
-  let width = max([&winwidth, a:maxWidth+1])
+  let width = max([winwidth(0), a:maxWidth+1])
   " But don't use more than half the width of vim
   exec 'vertical resize '.min([&columns/2, width])
 

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -287,7 +287,6 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
 
   " Setup syntax
   if has("syntax")
-    syntax on
     exec "syn match RenamerSecondaryInstructions '^\s*".s:hashes.".*'"
     exec "syn match RenamerPrimaryInstructions   '^\s*".s:hashes."Renamer.*'"
     exec "syn match RenamerLinkInfo '".s:linkPrefix.".*'"
@@ -383,7 +382,6 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
   " Restore things
   let &report=oldRep
   let &sc = save_sc
-
 endfunction
 
 function renamer#CreateOriginalFileWindow(needNewWindow, maxWidth, entryDisplayText) "{{{1

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -11,9 +11,9 @@ rename a bunch of files, especially when you want to do a common text
 manipulation to those file names, this plugin may help.  It shows you all
 the files in the current directory (and optionally in those below it),
 and lets you edit their names in the vim buffer.  When you're ready,
-issue the command ":Ren" to perform the mass rename.  Relative paths
-can be given, and new directories will be created, with 755 permissions,
-as required.
+issue the command |:Ren| to perform the mass rename, or check with |:RenTest|.
+Relative paths can be given, and new directories will be created, with 755
+permissions, as required.
 
 USAGE                                                   *renamer-usage* {{{1
 :Renamer {dir}                                          *:Renamer*
@@ -24,6 +24,8 @@ The VimRenamer window contains a directory listing. You can modify
 filenames and remove files.
 
 :Ren or :w (see g:RenamerSupportColonWToRename) will apply your changes.
+:RenTest will just show what will be moved (and which new directories will be
+created).
 
 Set the user configurable variables defined in plugin/renamer.vim as desired.
 

--- a/plugin/renamer.vim
+++ b/plugin/renamer.vim
@@ -58,41 +58,6 @@ if !exists('g:RenamerSupportColonWToRename')
   let g:RenamerSupportColonWToRename = 0
 endif
 
-" Highlight links
-" g:RenamerHighlightForPrimaryInstructions {{{2
-if !exists('g:RenamerHighlightForPrimaryInstructions')
-  let g:RenamerHighlightForPrimaryInstructions = 'Todo'
-endif
-
-" g:RenamerHighlightForSecondaryInstructions {{{2
-if !exists('g:RenamerHighlightForSecondaryInstructions')
-  let g:RenamerHighlightForSecondaryInstructions = 'comment'
-endif
-
-" g:RenamerHighlightForLinkInfo {{{2
-if !exists('g:RenamerHighlightForLinkInfo')
-  let g:RenamerHighlightForLinkInfo = 'comment'
-endif
-
-" g:RenamerHighlightForModifiedFilename {{{2
-if !exists('g:RenamerHighlightForModifiedFilename')
-  let g:RenamerHighlightForModifiedFilename = 'Constant'
-endif
-
-" g:RenamerHighlightForOriginalFilename {{{2
-if !exists('g:RenamerHighlightForOriginalFilename')
-  let g:RenamerHighlightForOriginalFilename = 'Keyword'
-endif
-
-" g:RenamerHighlightForNonWriteableEntries {{{2
-if !exists('g:RenamerHighlightForNonWriteableEntries')
-  let g:RenamerHighlightForNonWriteableEntries = 'NonText'
-endif
-
-" g:RenamerHighlightForOriginalDirectoryName {{{2
-if !exists('g:RenamerHighlightForOriginalDirectoryName')
-  let g:RenamerHighlightForOriginalDirectoryName = 'bold'
-endif
 
 
 


### PR DESCRIPTION
I merged a ton of changes from @inkarkat's renamer.vim repo. I haven't done a lot of testing, but wanted to get some feedback on the change.

I couldn't merge these changes because I think they were implemented (in a different way) in fc95e9a8b256ae128b1b7279b0cc8024ebf93f3f:
- inkarkat/renamer.vim@0d9cb0d  ENH: Allow recursive file listing. (2 years, 4 months ago)
- inkarkat/renamer.vim@13afe2d  Fix validChars for multi-byte file name (4 years, 1 month ago)

It contains some vimscript cleanup/refactoring, improved tooltips, and a test rename command.
