### PR TITLE
add explorer context menu batch script

### DIFF
--- a/doc/AddVimRenamerToContextMenu.bat
+++ b/doc/AddVimRenamerToContextMenu.bat
@@ -1,0 +1,14 @@
+@echo off
+SET exePath=c:\Program Files (x86)\Vim\vim80\gvim.exe
+SET menuEntry=Rename with VimRenamer
+
+rem add it for all file types
+@reg add "HKEY_CLASSES_ROOT\*\shell\%menuEntry%"         /t REG_SZ /v "" /d "%menuEntry%" /f
+@reg add "HKEY_CLASSES_ROOT\*\shell\%menuEntry%"         /t REG_EXPAND_SZ /v "Icon" /d "%exePath%,0" /f
+@reg add "HKEY_CLASSES_ROOT\*\shell\%menuEntry%\command" /t REG_SZ /v "" /d "%exePath% -c \"silent cd %%2^|Renamer\"" /f
+
+rem add it for folders
+@reg add "HKEY_CLASSES_ROOT\Folder\shell\%menuEntry%"         /t REG_SZ /v "" /d "%menuEntry%" /f
+@reg add "HKEY_CLASSES_ROOT\Folder\shell\%menuEntry%"         /t REG_EXPAND_SZ /v "Icon" /d "%exePath%,0" /f
+@reg add "HKEY_CLASSES_ROOT\Folder\shell\%menuEntry%\command" /t REG_SZ /v "" /d "%exePath% -c \"silent cd %%1^|Renamer\"" /f
+pause

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -38,7 +38,16 @@ INSTALL DETAILS                                       *renamer-install* {{{1
 The usual pathogen setup - add renamer directory to $HOME/.vim/bundle
 directory.
 
-INSTALLING TO WINDOWS XP/7 RIGHT CLICK MENU       *renamer-win-right-click*
+INSTALLING TO WINDOWS XP/7/8 RIGHT CLICK MENU       *renamer-win-right-click*
+You may use the included batch script "AddVimRenamerToContextMenu.bat"
+to automatically add context menu entries. This script adds context menu
+entries for folders AND FILES. The result is the same for both: open
+vim-renamer with the target folder. I just added this for convenience.
+You may delete the "add it for all file types" section, if you don't like
+this. Plus feel free to modify the menuEntry string.
+
+For reference: this is the old manual guide:
+
 To add running this script on a directory as a right click menu option,
 in Windows XP or 7, if you are confident working with the registry, do as
 follows (NOTE - THESE INSTRUCTIONS CAME FROM THE WEB AND WORKED FOR


### PR DESCRIPTION
I use VimRenamer quite regularly and got annoyed that you don't get the explorer context menu when right clicking on FILES. This is quite handy for directory containing lots of files, where you have to literally search for free space to get the folder context menu.

So I just added the context menu for files, too!
![context_menu](https://cloud.githubusercontent.com/assets/1249745/23456665/ac63a56c-fe74-11e6-95d1-0fbb82a86579.png)

Because adding all the registry entries manually is quite cumbersome, I modified @mrchief's [nice batch file](https://gist.github.com/mrchief/5628677) to do this for me. Using the batch you even git the beautiful VIM icon next to the menu entry :-)