### PR TITLE
Windows OS ,Fix "[]" in dirname , globPath() did not correctly escape the string . And a small improvement for this handy plugin.

### DIFF
--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -355,7 +355,7 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
     cnoremap <buffer> <CR> <C-\>eRenamerCheckUserCommand()<CR><CR>
     function! RenamerCheckUserCommand()
       let cmd = getcmdline()
-      if cmd == 'w'
+      if cmd =~# '\v<(up[!]?$)|(w[!]?$)'
         let cmd = 'Ren'
       elseif cmd == 'wq'
         let cmd = "Ren|quit"

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -350,7 +350,7 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
   command! -buffer -bang -bar -nargs=0 Ren     call renamer#PerformRename(0)
   command! -buffer -bang -nargs=0      RenTest call renamer#PerformRename(1)
 
-  if g:RenamerSupportColonWToRename
+  " if g:RenamerSupportColonWToRename
     " Enable :w<cr> and :wq<cr> to work as well
     cnoremap <buffer> <CR> <C-\>eRenamerCheckUserCommand()<CR><CR>
     function! RenamerCheckUserCommand()
@@ -362,7 +362,7 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
       endif
       return cmd
     endfunction
-  endif
+  " endif
 
   " Define the mapping to change directories
   nnoremap <buffer> <silent> <CR> :call renamer#ChangeDirectory()<CR>

--- a/autoload/renamer.vim
+++ b/autoload/renamer.vim
@@ -128,6 +128,8 @@ function renamer#Start(needNewWindow, startLine, startDirectory) "{{{1
     let basePath = b:renamerDirectoryEscaped
   else
     let basePath = b:renamerDirectory
+    "Fix "[]"  in windows dirname globPath not Escaped
+    let basePath = substitute(basePath ,'[','[[]',"g")
   endif
 
   let globPath = basePath . "/*"


### PR DESCRIPTION
In a dir like  "[LK][name][VERSION]"   vim-renamer just didnot work. 
This pr fixed it .

I have a map :  nmap <leader>w :setlocal swf\|up!<cr> ,
the 2nd  patch makes the map works .